### PR TITLE
Clean up and consolidate UI layout

### DIFF
--- a/web_external/HeaderBar/index.jsx
+++ b/web_external/HeaderBar/index.jsx
@@ -22,7 +22,6 @@ class HeaderBar extends Component {
             <div className='load-button-container'>
                 <button className='btn btn-primary' onClick={(e) => this.openClicked(e)}>Load</button>
             </div>
-            <div className='v-logo-wrapper'>VPView Web</div>
             <div className='v-current-user-text'></div>
             <div className='v-current-user-wrapper'>
                 {user ?

--- a/web_external/HeaderBar/index.jsx
+++ b/web_external/HeaderBar/index.jsx
@@ -19,11 +19,11 @@ class HeaderBar extends Component {
     render() {
         let user = this.state.user;
         return <div className={['v-header-wrapper', this.props.className].join(' ')}>
-            <div className='load-button-container'>
+            <div className='toolbutton'>
                 <button className='btn btn-primary' onClick={(e) => this.openClicked(e)}>Load</button>
             </div>
             <div className='v-current-user-text'></div>
-            <div className='v-current-user-wrapper'>
+            <div className='v-current-user-wrapper toolbutton'>
                 {user ?
                     <div className='v-user-link-wrapper'>
                         <a className='v-user-link' data-toggle='dropdown' data-target='#g-user-action-menu'>

--- a/web_external/HeaderBar/style.styl
+++ b/web_external/HeaderBar/style.styl
@@ -4,6 +4,7 @@
   height $headerHeight
   background-color $headerColor
   transition background-color 0.4s ease-in-out
+  padding 1px
 
   .v-logo-wrapper
     display flex
@@ -65,9 +66,13 @@
 
       &:active
         background linear-gradient(bottom, white 60%, #f6f6f6 100%)
-    
-  .load-button-container
-    button.btn
-      padding 3px 4px
-      margin-top 1px
 
+  div.toolbutton
+    a
+    button.btn
+      display inline-block
+      vertical-align center
+      padding 3px 4px
+
+    a
+      border 1px solid transparent

--- a/web_external/HeaderBar/style.styl
+++ b/web_external/HeaderBar/style.styl
@@ -1,13 +1,9 @@
 .v-header-wrapper
   display flex
-  position fixed
-  top 0
-  left 0
   width 100%
   height $headerHeight
   background-color $headerColor
   transition background-color 0.4s ease-in-out
-  z-index 10
 
   .v-logo-wrapper
     display flex

--- a/web_external/IndexView/style.styl
+++ b/web_external/IndexView/style.styl
@@ -1,16 +1,17 @@
-.v-header
-  height 30px
+.app
+  display flex
+  flex-direction column
 
 .v-index
-  margin-top 30px
-  height calc(100% - 30px)
+  height 100%
+  flex 1
   display flex
   flex-flow row
 
   .left-sidebar
     width 320px
     padding 1px
-  
+
   .main
     flex 1
     padding 1px
@@ -20,12 +21,39 @@
     padding 1px
 
 .panel
-  border-radius 2px
+  border-radius 3px
 
   .panel-heading
-    padding 7px 10px
-    border-radius 2px
+    padding 0.3em 0.5em
+    border-radius 3px 3px 0 0
     cursor default
+    text-align center
 
   .panel-body
-    padding 7px 10px
+    padding 3px
+
+  .nav.nav-tabs
+    width 100%
+    display table
+    border none
+
+    > li
+      display table-cell
+      text-align center
+      white-space nowrap
+      margin initial
+      float none
+
+      > a
+        padding 0 0.5em
+        border none
+
+    > li:not(:first-child)
+      border-left 1px solid #ddd
+
+    > li:not(.active)
+      opacity 0.6
+
+    li.active > a
+        background none
+        border-radius 3px

--- a/web_external/TrackAttribute/index.jsx
+++ b/web_external/TrackAttribute/index.jsx
@@ -12,7 +12,7 @@ class TrackAttribute extends Component {
     render() {
         return <div className={['v-trackattribute', this.props.className].join(' ')}>
             <div className='panel panel-default'>
-                <div className='panel-heading'>Track Attribute</div>
+                <div className='panel-heading'>Attributes</div>
                 <div className='panel-body'>
                     <ul>
                         {Object.entries(this.state.trackAttributes).map(([category, attributes], index) => {

--- a/web_external/TreeView/index.jsx
+++ b/web_external/TreeView/index.jsx
@@ -14,14 +14,10 @@ class TreeView extends Component {
     render() {
         return <div className={['v-treeview', this.props.className].join(' ')}>
             <div className='panel panel-default'>
-                <div className='panel-heading'>Tree View</div>
-                <div className='panel-body'>
+                <div className='panel-heading'>
                     <ul className='nav nav-tabs'>
                         <li>
                             <a data-toggle='tab' href='#activities'>Activities</a>
-                        </li>
-                        <li>
-                            <a data-toggle='tab' href='#events'>Events</a>
                         </li>
                         <li className='active'>
                             <a data-toggle='tab' href='#tracks'>Tracks</a>
@@ -30,9 +26,10 @@ class TreeView extends Component {
                             <a data-toggle='tab' href='#scene-elements'>Scene Elements</a>
                         </li>
                     </ul>
+                </div>
+                <div className='panel-body'>
                     <div className='tab-content'>
                         <div id='activities' className='tab-pane'>1</div>
-                        <div id='events' className='tab-pane'>2</div>
                         <div id='tracks' className='tab-pane active'>
                             <ul className='item-list'>
                                 {this.state.tracks.map((track, index) => {

--- a/web_external/TreeView/style.styl
+++ b/web_external/TreeView/style.styl
@@ -7,10 +7,17 @@
     flex-direction column
 
   .panel-body
-    overflow-y scroll
+    position relative
+    height 100%
+    flex 1
 
-  .nav.nav-tabs li a
-    padding 2px 3px
+  .tab-content
+    position absolute
+    top 3px
+    left 3px
+    right 3px
+    bottom 3px
+    overflow-y scroll
 
   ul.item-list
     list-style none

--- a/web_external/Viewer/index.jsx
+++ b/web_external/Viewer/index.jsx
@@ -30,7 +30,6 @@ class Viewer extends Component {
     render() {
         return <div className={['v-viewer', this.props.className].join(' ')}>
             <div className='panel panel-default'>
-                <div className='panel-heading'><br /></div>
                 <div className='panel-body'>
                     {this.state.itemModel &&
                         [<ImageViewerWidgetWrapper className='video'

--- a/web_external/Viewer/style.styl
+++ b/web_external/Viewer/style.styl
@@ -18,7 +18,7 @@
     padding 10px
 
     .buttons
-      width 40%
+      width auto
       margin 0 auto
       display flex
       height 30px


### PR DESCRIPTION
Remove some unnecessary UI elements. Fix overflow in tree view. Tweak styling so that tabs can be merged into the panel header (and are visually consistent with static headers). Fix layout of top header, which was not size-responsive (not the only issue we have in that department, but it's an improvement). Tweak assorted other elements for improved aesthetics.