### PR TITLE
Improve style of 'no annotations' watermark

### DIFF
--- a/web_external/Viewer/index.jsx
+++ b/web_external/Viewer/index.jsx
@@ -63,7 +63,7 @@ class Viewer extends Component {
                             }}
                             key={this.props.itemModel.id} />,
                         this.state.ready && !this.props.annotationGeometryContainer
-                        && <div className='no-annotation-message alert alert-danger' key='no-annotation-message'>
+                        && <div className='no-annotation-message' key='no-annotation-message'>
                             <span>No annotation</span>
                         </div>,
                         <div className='control' key='control'>

--- a/web_external/Viewer/style.styl
+++ b/web_external/Viewer/style.styl
@@ -21,7 +21,11 @@
     right 3px
     z-index 1
     padding 0 0.5em
-  
+    border-radius 0
+    background rgba(255, 224, 224, 0.5)
+    border 1px solid rgba(160, 80, 80, 0.5)
+    color #400
+
   .control
     padding-top 3px
 


### PR DESCRIPTION
Use custom style rules instead of bootstrap for the 'no annotations' watermark. This allows us to fully tuck the watermark into the corner (without a funky notch due to corner rounding) and to give it a translucent background and border color that is aesthetically pleasing on top of video.