### PR TITLE
Improve info pane

### DIFF
--- a/web_external/InfoView/index.jsx
+++ b/web_external/InfoView/index.jsx
@@ -11,35 +11,29 @@ class InfoView extends PureComponent {
             <div className='panel panel-default'>
                 <div className='panel-heading'>Info</div>
                 <div className='panel-body'>
-                    {this.props.annotations && this.props.annotations.length !== 0 &&
-                        <div>
-                            <ul className='geometry'>
-                                {this.props.annotations.map((annotation) => {
-                                    var type = annotation.type ? `${annotation.geometry.id1} (${annotation.type.obj_type})` : annotation.geometry.id1;
-                                    return <li key={`${annotation.geometry.id0}-${annotation.geometry.id1}`} className='track'>
-                                        <div>
-                                            <div>{type}</div>
-                                            <div>Geometry id: {annotation.geometry.id0}</div>
-                                            <div>Frame id: {annotation.geometry.ts0}</div>
-                                            {Object.entries(annotation.geometry.keyValues).map(([key, value], index) => {
-                                                return <div key={index}>{key}: {value}</div>
-                                            })}
-                                            {annotation.activities && annotation.activities.length !== 0
-                                                && <ul className='activity'>
-                                                    {annotation.activities.map((activity) => {
-                                                        return <li key={activity.id2} className='activity'>
-                                                            <div>Activity Id: {activity.id2}</div>
-                                                            <div>Activity: {activity.act2}</div>
-                                                        </li>
-                                                    })}
-                                                </ul>}
-                                        </div>
-                                    </li>
+                    <ul className='geometry'>
+                        {this.props.annotations && this.props.annotations.map((annotation) => {
+                            var type = annotation.type ? `${annotation.geometry.id1} (${annotation.type.obj_type})` : annotation.geometry.id1;
+                            return <li key={`${annotation.geometry.id0}-${annotation.geometry.id1}`} className='track'>
+                                <div>{type}</div>
+                                <div>Geometry id: {annotation.geometry.id0}</div>
+                                <div>Frame id: {annotation.geometry.ts0}</div>
+                                {Object.entries(annotation.geometry.keyValues).map(([key, value], index) => {
+                                    return <div key={index}>{key}: {value}</div>
                                 })}
-                            </ul>
-                            <div className='clear-message'>(click outside annotation to clear)</div>
-                        </div>
-                    }
+                                {annotation.activities && annotation.activities.length !== 0
+                                    && <ul className='activity'>
+                                        {annotation.activities.map((activity) => {
+                                            return <li key={activity.id2} className='activity'>
+                                                <div>Activity Id: {activity.id2}</div>
+                                                <div>Activity: {activity.act2}</div>
+                                            </li>
+                                        })}
+                                    </ul>}
+                            </li>
+                        })}
+                    </ul>
+                    <div className='clear-message'>(Click an annotation to view details. Click on an empty space to clear.)</div>
                 </div>
             </div>
         </div>

--- a/web_external/InfoView/style.styl
+++ b/web_external/InfoView/style.styl
@@ -30,3 +30,4 @@
     left 0
     right 0
     text-align center
+    opacity 0.6

--- a/web_external/InfoView/style.styl
+++ b/web_external/InfoView/style.styl
@@ -8,9 +8,12 @@
 
   .panel-body
     flex 1
-    position relative
+    display flex
+    flex-direction column
 
   ul
+    flex 1
+
     &.geometry
       padding-left 20px
 
@@ -25,9 +28,7 @@
         margin-bottom 2px
 
   .clear-message
-    position absolute
-    bottom 0
-    left 0
-    right 0
+    align-self flex-end
+    height auto
     text-align center
     opacity 0.6

--- a/web_external/InfoView/style.styl
+++ b/web_external/InfoView/style.styl
@@ -7,12 +7,14 @@
     flex-direction column
 
   .panel-body
-    flex 1
+    flex 1 1 0
     display flex
     flex-direction column
+    overflow-y hidden
 
   ul
     flex 1
+    overflow-y auto
 
     &.geometry
       padding-left 20px
@@ -29,6 +31,5 @@
 
   .clear-message
     align-self flex-end
-    height auto
     text-align center
     opacity 0.6


### PR DESCRIPTION
Avoid superfluous DOM elements. Improve "hint" message text and appearance. Use text-relative dimensions for things that need to be relative to the text size. Use flex to show hint at bottom rather than absolute positioning. Fix overflow in info pane (#21).