### PR TITLE
Tweak 'loading' watermark

### DIFF
--- a/web_external/Viewer/index.jsx
+++ b/web_external/Viewer/index.jsx
@@ -64,8 +64,8 @@ class Viewer extends PureComponent {
                             }}
                             annotationsSelect={this.props.annotationsSelect}
                             key={this.props.itemModel.id} />,
-                        message && <div className='message' key='message'>
-                            <span>{message}</span>
+                        message && <div className={message.classes} key='message'>
+                            <span>{message.text}</span>
                         </div>,
                         <div className='control' key='control'>
                             <div className='buttons btn-group'>
@@ -160,10 +160,10 @@ class Viewer extends PureComponent {
 
     _getMessage() {
         if (this.props.isLoadingAnnotation || !this.state.ready) {
-            return 'Loading...';
+            return {text: 'Loading...', classes: 'message info-message'};
         }
         if (!this.props.isLoadingAnnotation && !this.props.annotationGeometryContainer) {
-            return 'No annotation';
+            return {text: 'No annotation', classes: 'message error-message'};
         }
     }
 

--- a/web_external/Viewer/style.styl
+++ b/web_external/Viewer/style.styl
@@ -22,6 +22,11 @@
     z-index 1
     padding 0 0.5em
     border-radius 0
+    background rgba(240, 240, 240, 0.5)
+    border 1px solid rgba(100, 100, 100, 0.5)
+    color #222
+
+  .error-message
     background rgba(255, 224, 224, 0.5)
     border 1px solid rgba(160, 80, 80, 0.5)
     color #400


### PR DESCRIPTION
Tweak internal message helper to also return a list of CSS classes. Tweak CSS for watermark messages to use a neutral color for the neutral 'loading' message.