### PR TITLE
Fix a bug that prevent video from being scrubbed to the beginning

### DIFF
--- a/web_external/Viewer/ImageViewerWidgetWrapper/VauiGeoJSImageViewer.js
+++ b/web_external/Viewer/ImageViewerWidgetWrapper/VauiGeoJSImageViewer.js
@@ -126,7 +126,6 @@ var VauiGeoJSImageViewer = GeojsImageViewerWidget.extend({
                                 });
                         }
                         else {
-                            console.log("pending frame", newFrame);
                             this.pendingFrame = newFrame;
                         }
                     }

--- a/web_external/Viewer/ImageViewerWidgetWrapper/VauiGeoJSImageViewer.js
+++ b/web_external/Viewer/ImageViewerWidgetWrapper/VauiGeoJSImageViewer.js
@@ -6,6 +6,7 @@ var VauiGeoJSImageViewer = GeojsImageViewerWidget.extend({
         GeojsImageViewerWidget.prototype.initialize.apply(this, arguments);
         this.getAnnotation = settings.getAnnotation;
         this._annotationClicks = [];
+        this.pendingFrame = null;
     },
 
     render() {
@@ -64,7 +65,7 @@ var VauiGeoJSImageViewer = GeojsImageViewerWidget.extend({
                 }
 
                 var next = () => {
-                    if (this.pendingFrame) {
+                    if (this.pendingFrame !== null) {
                         frame = this.pendingFrame;
                         this.pendingFrame = null;
                     }
@@ -79,7 +80,7 @@ var VauiGeoJSImageViewer = GeojsImageViewerWidget.extend({
                         updateFrame(frame)
                             .then(() => {
                                 pendingNext = false;
-                                if (!this.pendingFrame) {
+                                if (this.pendingFrame === null) {
                                     this.trigger('progress', frame, ids.length);
                                 }
                                 // if we haven't asked to stop, go to the next frame as soon as
@@ -125,6 +126,7 @@ var VauiGeoJSImageViewer = GeojsImageViewerWidget.extend({
                                 });
                         }
                         else {
+                            console.log("pending frame", newFrame);
                             this.pendingFrame = newFrame;
                         }
                     }


### PR DESCRIPTION
When the pendingFrame is 0, if(pendingFrame) become false, however, 0 is the pending frame we are looking for.
This fixes the issue https://github.com/Kitware/vaui/issues/25