### PR TITLE
Fix context menu z-index

### DIFF
--- a/web_external/Viewer/style.styl
+++ b/web_external/Viewer/style.styl
@@ -66,5 +66,8 @@
       .spinbox
         margin-left 4px
 
+  .v-viewer-wrapper.geojs-map
+    z-index 0
+
   .v-viewer-wrapper.geojs-map:focus
     outline none


### PR DESCRIPTION
Increase the CSS `z-index` for context menus. This is necessary to avoid the menu being rendered beneath the main geoJS view.